### PR TITLE
Make codemirror a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 ## Usage instructions
 
-1. Install codemirror-mode elixir from NPM: `npm install
-codemirror-mode-elixir`
+1. Install `codemirror` and `codemirror-mode-elixir` from NPM: `npm install
+codemirror codemirror-mode-elixir`
 
-2. Include codemirror-mode-elixir into your project.
+2. Include `codemirror-mode-elixir` into your project.
 
   ```html
   <!-- You can simply add elixir.js as a script tag: -->

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "author": "Ian Walter <public@iankwalter.com>",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "codemirror": "^5.20.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey @ianwalter thanks for making this codemirror mode!

I'm using it with Webpack and ran into the issue that Webpack was including two versions of codemirror into my build, because this projects specifies codemirror as a direct dependency.

This PR makes codemirror a peerDependency. I've updated the README to reflect that codemirror itself should be installed separately. I've left the version specifier as it was, which makes this mode compatible with any version of codemirror > `5.20.2`.